### PR TITLE
Fix: Updated adminportal/registrations.html to fix profile_picture ValueError

### DIFF
--- a/templates/adminportal/registrations.html
+++ b/templates/adminportal/registrations.html
@@ -61,7 +61,11 @@
                 <div class="card mb-3">
                     <div class="row no-gutters">
                         <div class="col-md-3">
-                            <img class="img-thumbnail" src="{{ profile.profile_picture.url }}" alt="Profile Picture" style="max-height:220px">
+                            {% if profile.profile_picture %}
+                                <img class="img-thumbnail" src="{{ profile.profile_picture.url }}" alt="Profile Picture" style="max-height:220px">
+                            {% else %}
+                                <img class="img-thumbnail" src="{% static 'AlumniConnect/img/user.png' %}" alt="Profile Picture" style="max-height:220px">
+                            {% endif %}
                         </div>
                         <div class="col-md-8">
                             <div class="card-body">


### PR DESCRIPTION
### Description of PR :
This PR fixes the ValueError regarding profile_picture attrribute  when `adminportal/registrations` route is hit.

When no profile picture is present, it defaults to a specific image.