### PR TITLE
Fix: updated map search to account for state

### DIFF
--- a/applications/members/views.py
+++ b/applications/members/views.py
@@ -132,13 +132,14 @@ def autoSearch(request):
 def mapSearch(request):
     location = request.GET.get('search', '')
     city = location.split(',', 1)[0]
+    state= location.split(',')[1].strip()
 
     profiles = Profile.objects.all()
     if city:
-        profiles = Profile.objects.filter(city__icontains=city)
+        profiles = Profile.objects.filter(city__icontains=city, state__icontains=state)
         profiles = profiles.order_by('name')
     else:
-        profiles = Profile.objects.filter(city=city)
+        profiles = Profile.objects.filter(city="")
 
     context = {
         'profiles': profiles,


### PR DESCRIPTION
Fixes issue: #126 

### Description:
This PR fixes the discrepancies in the profiles shown on the result page due to same city name.

The map search now accounts for state along with city to filter out profiles effectively.