### PR TITLE
Fixes #146. Fix(award page of the website by reframing it) Adding a default /awards/ page.

### DIFF
--- a/applications/awards/views.py
+++ b/applications/awards/views.py
@@ -4,7 +4,9 @@ from .models import Award
 
 # Create your views here.
 def index(request):
-    return render(request, "awards/index.html")
+    awards = Award.objects.all()
+    award_count = awards.count()
+    return render(request, "awards/index.html", {"awards": awards, "award_count": award_count})
 
 
 def award(request, id):

--- a/templates/awards/index.html
+++ b/templates/awards/index.html
@@ -1,1 +1,43 @@
-Lets get started !
+{% extends 'globals/base.html' %}
+{% load static %}
+
+{% block title %}
+    Awards
+{% endblock %}
+
+{% block body %}
+    {% include 'globals/navbar.html' %}
+    <div class="p-0 m-0 masthead-bg w-100 parallax shadow-sm" style="min-height:250px !important; height:270px !important; background-position-y: 270px;"></div>
+    <div style="height:150px; min-height:150px;"></div>
+
+    <div class="container text-left p-2 mx-auto">
+        <div class="card shadow m-4 bg-light">
+            <div class="card-body">
+                <h1 class="card-title">Awards Display:-  </h1>
+                <p class="m-2 font-weight-normal mb-3">
+                    <span class="d-inline-block pb-1 pb-md-0">
+                        <i class="fas fa-trophy"></i>
+                        {{ award_count }} awards to display!
+                    </span>
+                </p>
+                <div class="awards-list">
+                    {% for award in awards %}
+                        <div class="award-item mb-4">
+                            <h2>{{ award.title|safe }}</h2>
+                            <p>
+                                <i class="fas fa-table"></i>
+                                {{ award.published_date|date:"d F, o" }}
+                                &nbsp;
+                                <i class="fas fa-user"></i>&nbsp;
+                                {{ award.by }}
+                            </p>
+                            <p>{{ award.description|safe }}</p>
+                        </div>
+                        <hr>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+    {% include 'globals/footer.html' %}
+{% endblock %}


### PR DESCRIPTION
### FIXES #146 

**1. This PR Fixes issue #146 (Add a default /awards/ page.)
2. This PR modifies the index.html file of the awards folder of the templates folder to display the total count and the award list on the awards page of the website. 
3. This PR modifies the views.py file of the awards application to apply the logic for displaying N number of awards on the webpage, N being the total number of awards.**

### PROOF THAT THE CHANGES ARE AUTHENTIC:-

**I Have listed 2 awards to show the webpage functionality.**

**VIDEO SHOWING THE DEMO**
1. The video displays the whole webpage
2. The video shows the responsiveness
3. The video shows the whole page, navbar,  footer and all necessary components.



https://github.com/BitByte-TPC/alumni/assets/136831315/3ac812f6-6da6-4f23-aa4d-ec008a7f6fb3


Please ignore the watermark, i had to compress the video for the 10mb file restriction on github.

**SCREENSHOTS:-**

<img width="1498" alt="Screenshot 2024-06-02 at 3 32 52 AM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/9a72c9b9-91d6-4c69-abe6-ab95ea23423e">

**This screenshot displays the awards page basically rendering the index.html page.**

<img width="1504" alt="Screenshot 2024-06-02 at 3 33 34 AM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/4b078e19-b066-4c7c-8cc0-b02b3819cade">

**This screenshot shows the responsive nature of the webpage across all devices**

Thank You. 

