### PR TITLE
Fixes #150 Adding default text for event entries not specified

### DIFF
--- a/templates/AlumniConnect/index.html
+++ b/templates/AlumniConnect/index.html
@@ -152,8 +152,13 @@
                     <i class="fas fa-calendar-alt font-weight-lighter " title="Start Date"></i>
                     {{item.start_date|date:"l, d M, o"}}
                     <br>
+                    {% if item.location %}
                     <i class="fas fa-map-marker-alt" title="Location"></i>
                     {{item.location}}
+                    {% else %}
+                    <i class="fas fa-map-marker-alt" title="Location"></i>
+                    N/A
+                    {% endif %}
                     <br>
                     <i class="fas fa-users" title="Number of Attendees"></i>
                     {{item.count}}

--- a/templates/events_news/event.html
+++ b/templates/events_news/event.html
@@ -55,15 +55,30 @@
 								{{ event.start_date|date:"d M, o" }}
 								&nbsp;
 							</span>
+							{% if event.location %}
 							<span class="d-inline-block mb-2">
 								<i class="fas fa-map-marker-alt"></i>
 								{{ event.location}}
 								&nbsp;
 							</span>
+							{% else %}
+							<span class="d-inline-block mb-2">
+								<i class="fas fa-map-marker-alt"></i>
+								N/A
+								&nbsp;
+							</span>
+							{% endif %}
+							{% if event.by %}
 							<span class="d-inline-block mb-2">
 								<i class="fas fa-user"></i>
 								{{ event.by }}
 							</span>
+							{% else %}
+							<span class="d-inline-block mb-2">
+								<i class="fas fa-user"></i>
+								N/A
+							</span>
+							{% endif %}
 						</p>
 						<div class="row">
 							{% if event.is_completed %}
@@ -247,15 +262,30 @@
 									{{ event.start_date|date:"d M, o" }}
 									&nbsp;
 								</span>
+								{% if event.location %}
 								<span class="d-inline-block mb-2">
 									<i class="fas fa-map-marker-alt"></i>
 									{{ event.location}}
 									&nbsp;
 								</span>
+								{% else %}
+								<span class="d-inline-block mb-2">
+									<i class="fas fa-map-marker-alt"></i>
+									N/A
+									&nbsp;
+								</span>
+								{% endif %}
+								{% if event.by %}
 								<span class="d-inline-block mb-2">
 									<i class="fas fa-user"></i>
 									{{ event.by }}
 								</span>
+								 {% else %}
+								 <span class="d-inline-block mb-2">
+									<i class="fas fa-user"></i>
+									N/A
+								</span>
+								{% endif %}
 							</p>
 							
 							<div class="row">

--- a/templates/events_news/index.html
+++ b/templates/events_news/index.html
@@ -75,14 +75,29 @@
                                     <i class="fas fa-table mr-2"></i>
                                     {{ item.start_date|date:"d F, o" }}
                                 </p>
+                                {% if item.location %}
                                 <p class="m-1">
                                     <i class="fas fa-map-marker-alt mr-2"></i>&nbsp;
-                                    {{ item.location}}
+                                    {{ item.location }}
                                 </p>
+                            {% else %}
+                                <p class="m-1">
+                                    <i class="fas fa-map-marker-alt mr-2"></i>&nbsp;
+                                    N/A
+                                </p>
+                            {% endif %}
+                                {% if item.by %}
                                 <p class="m-1">
                                     <i class="fas fa-user mr-2"></i>
                                     {{ item.by }}
-                                </p>  
+                                </p> 
+                             {% else %}
+                             <p class="m-1">
+                                <i class="fas fa-user mr-2"></i>
+                                N/A
+                            </p> 
+                            {% endif %}
+                                   
                             </p>
                             <a href="{% url 'events_news:event' id=item.event_id %}" class="btn btn-primary btn-sm card-link px-4 py-2">View</a>
                         </div>


### PR DESCRIPTION
**Fixes #150** 

This PR does the following:-
1. Modifies the index.html page in the events_news folder of the templates folder.
2. Whenever there is an empty field, while creating an event through the admin portal, it displays N/A instead of leaving it blank.
3. Used basic if block to conditionally check whether the fields are filled or not and thereby display the proper message accordingly,


### **PROOF OF WORK**

https://github.com/BitByte-TPC/alumni/assets/136831315/38407c88-a6db-4429-83ab-fb82b4bab3f2

**This Screen Recording shows the entire process and also displays when the fields are not filled, it's displaying N/A and it also shows that when the fields are filled all the content are displayed. Therefore it does not hamper the general process**

**Additional Screenshots to support it-**
<img width="1103" alt="Screenshot 2024-06-06 at 12 36 05 PM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/ad323e82-371d-42b3-b190-4ca7e28bf665">

<img width="1114" alt="Screenshot 2024-06-06 at 12 35 54 PM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/05af656f-02c4-49a4-97a8-bd3bde0895be">

Thank You.

Fixes #150 

